### PR TITLE
Configuring ssl certs path for ubuntu

### DIFF
--- a/lib/omniauth/strategies/cas/service_ticket_validator.rb
+++ b/lib/omniauth/strategies/cas/service_ticket_validator.rb
@@ -78,7 +78,10 @@ module OmniAuth
           result = ''
           http = Net::HTTP.new(@uri.host, @uri.port)
           http.use_ssl = @uri.port == 443 || @uri.instance_of?(URI::HTTPS)
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl? && @options.disable_ssl_verification?
+          if http.use_ssl?
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @options.disable_ssl_verification?
+            http.ca_path = '/etc/ssl/certs' if File.exists? '/etc/ssl/certs' # ruby19 ubuntu
+          end
           http.start do |c|
             response = c.get "#{@uri.path}?#{@uri.query}", VALIDATION_REQUEST_HEADERS.dup
             result = response.body


### PR DESCRIPTION
When using ruby19 on ubuntu ssl verification returns this error:

SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)

But after set the path of certs everything works fine.
