### PR TITLE
Upgrading nokogiri dependency to ~> 1.6

### DIFF
--- a/omniauth-cas.gemspec
+++ b/omniauth-cas.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Omniauth::Cas::VERSION
 
   gem.add_dependency 'omniauth',                '~> 1.1.0'
-  gem.add_dependency 'nokogiri',                '~> 1.5'
+  gem.add_dependency 'nokogiri',                '~> 1.6'
   gem.add_dependency 'addressable',             '~> 2.3'
 
   gem.add_development_dependency 'rake',        '~> 0.9'


### PR DESCRIPTION
Hi Derek,
I'm facing a dependency problem in my project, using omniauth-cas and others gems that require nokogiri verion 1.6. I have upgraded Gemspec : all specs have passed, with nokogiri 1.6.

Let me know what you think about that.
best regards,

Pilooz
