### PR TITLE
Update nokogiri dependency >= 1.5

### DIFF
--- a/omniauth-cas.gemspec
+++ b/omniauth-cas.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Omniauth::Cas::VERSION
 
   gem.add_dependency 'omniauth',                '~> 1.1.0'
-  gem.add_dependency 'nokogiri',                '~> 1.6'
+  gem.add_dependency 'nokogiri',                '>= 1.5'
   gem.add_dependency 'addressable',             '~> 2.3'
 
   gem.add_development_dependency 'rake',        '~> 0.9'


### PR DESCRIPTION
Following http://guides.rubygems.org/patterns/

A previous update forcing only Nokogiri 1.6 breaks several applications.  Since Nokogiri 1.5 still works just fine I modified the dependency to be `>= 1.5` which accounts for Nokogiri 1.6 as well.
