### PR TITLE
Add `nickname` to info hash.

### DIFF
--- a/lib/omniauth/strategies/cas.rb
+++ b/lib/omniauth/strategies/cas.rb
@@ -29,6 +29,7 @@ module OmniAuth
       option :uid_field,            'user'
       option :name_key,             'name'
       option :email_key,            'email'
+      option :nickname_key,         'user'
       option :first_name_key,       'first_name'
       option :last_name_key,        'last_name'
       option :location_key,         'location'
@@ -36,11 +37,12 @@ module OmniAuth
       option :phone_key,            'phone'
 
       # As required by https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema
-      AuthHashSchemaKeys = %w{name email first_name last_name location image phone}
+      AuthHashSchemaKeys = %w{name email nickname first_name last_name location image phone}
       info do
         prune!({
           :name       => raw_info[ @options[:name_key].to_s ],
           :email      => raw_info[ @options[:email_key].to_s ],
+          :nickname   => raw_info[ @options[:nickname_key].to_s ],
           :first_name => raw_info[ @options[:first_name_key].to_s ],
           :last_name  => raw_info[ @options[:last_name_key].to_s ],
           :location   => raw_info[ @options[:location_key].to_s ],


### PR DESCRIPTION
Also, expose a `nickname_key` setting, defaulting to 'user'.

I'm adding this because:
1. It's [in the spec](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema#schema-10-and-later).
2. At some point GitLab starting [using it to populate its username](https://github.com/gitlabhq/gitlabhq/blob/master/lib/gitlab/oauth/user.rb#L71).

I don't know for sure that this is the best way to handle that, as I feel as though GitLab is kind of Doing it Wrong™, but that's your call.

Incidentally, do you have any plans to make another release and push it to rubygems at any point? I'd like to use this in production but I like releases...
