### PR TITLE
Allow for namespaces declared outside of the root element in single sign out requests

### DIFF
--- a/lib/omniauth/strategies/cas/logout_request.rb
+++ b/lib/omniauth/strategies/cas/logout_request.rb
@@ -31,8 +31,9 @@ module OmniAuth
         def logout_request
           @logout_request ||= begin
             saml = Nokogiri.parse(@request.params['logoutRequest'])
-            name_id = saml.xpath('//saml:NameID').text
-            sess_idx = saml.xpath('//samlp:SessionIndex').text
+            ns = saml.collect_namespaces
+            name_id = saml.xpath('//saml:NameID', ns).text
+            sess_idx = saml.xpath('//samlp:SessionIndex', ns).text
             inject_params(name_id:name_id, session_index:sess_idx)
             @request
           end


### PR DESCRIPTION
The CAS server I'm using declares the `saml` namespace inside the NameID element:

```
<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="foobarbaz" Version="2.0" IssueInstant="2014-10-19T17:13:50Z">
    <saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@NOT_USED@</saml:NameID>
    <samlp:SessionIndex>ST-foo-bar</samlp:SessionIndex>
</samlp:LogoutRequest>
```

Nokogiri only looks for namespace declarations in the root element, then raises an exception when it can't find one that was declared elsewhere. This PR forces Nokogiri to scan the entire xml document for namespaces before accessing any nodes.
