### PR TITLE
specify namespace while using xpath

### DIFF
--- a/lib/omniauth/strategies/cas/logout_request.rb
+++ b/lib/omniauth/strategies/cas/logout_request.rb
@@ -2,6 +2,10 @@ module OmniAuth
   module Strategies
     class CAS
       class LogoutRequest
+
+        NS_SAML   = "urn:oasis:names:tc:SAML:2.0:assertion"
+        NS_SAMLP  = "urn:oasis:names:tc:SAML:2.0:protocol"
+
         def initialize(strategy, request)
           @strategy, @request = strategy, request
         end
@@ -31,8 +35,8 @@ module OmniAuth
         def logout_request
           @logout_request ||= begin
             saml = Nokogiri.parse(@request.params['logoutRequest'])
-            name_id = saml.xpath('//saml:NameID').text
-            sess_idx = saml.xpath('//samlp:SessionIndex').text
+            name_id = saml.xpath('//saml:NameID', :saml => NS_SAML).text
+            sess_idx = saml.xpath('//samlp:SessionIndex', :samlp => NS_SAMLP).text
             inject_params(name_id:name_id, session_index:sess_idx)
             @request
           end


### PR DESCRIPTION
Some cas servers send this XML file:
```
<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="LR-3-JVgp7bbMHiwILUsnQHunXED3vrfEl57pbpZ" Version="2.0" IssueInstant="2017-06-29T10:56:17Z">
  <saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@NOT_USED@</saml:NameID>
  <samlp:SessionIndex>ST-3-2ORKCpJ9HsnAT0v9df5U-cas01.example.org</samlp:SessionIndex>
</samlp:LogoutRequest>
```

As you can see, the namespace "saml" is not defined in the root,
so Nokogiri does not register it automatically, leading to this error on
single sign out request:
```
Started POST "/users/auth/cas/callback?url=http%3A%2F%2Flocalhost%3A3000%2Fusers%2Fsign_in" for 127.0.0.1 at 2017-06-29 10:56:17 +0200
I, [2017-06-29T10:56:17.300172 #92436]  INFO -- omniauth: (cas) Callback phase initiated.
E, [2017-06-29T10:56:17.308365 #92436] ERROR -- omniauth: (cas) Authentication failure! logout_request: Nokogiri::XML::XPath::SyntaxError, Undefined namespace prefix: //saml:NameID
Processing by Users::OmniauthCallbacksController#failure as HTML
  Parameters: {"logoutRequest"=>"<samlp:LogoutRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" ID=\"LR-3-JVgp7bbMHiwILUsnQHunXED3vrfEl57pbpZ\" Version=\"2.0\" IssueInstant=\"2017-06-29T10:56:17Z\"><saml:NameID xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">@NOT_USED@</saml:NameID><samlp:SessionIndex>ST-3-2ORKCpJ9HsnAT0v9df5U-cas01.example.org</samlp:SessionIndex></samlp:LogoutRequest>", "url"=>"http://localhost:3000/users/sign_in"}
Can't verify CSRF token authenticity
Completed 422 Unprocessable Entity in 2ms (ActiveRecord: 0.0ms)
```

I added the namespace mapping to every xpath query