### PR TITLE
Forward success response to fetch_raw_info callback (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,13 @@ Other configuration options:
 
     ```ruby
     provider :cas,
-             fetch_raw_info: lambda { |strategy, options, ticket, user_info|
-               ExternalService.get(user_info[:user]).attributes
-            }
+      fetch_raw_info: Proc.new { |strategy, opts, ticket, user_info, rawxml|
+        return {} if user_info.empty? || rawxml.nil? # Auth failed
+
+        extra_info = ExternalService.get(user_info[:user]).attributes
+        extra_info.merge!({'roles' => rawxml.xpath('//cas:roles').map(&:text)})
+        extra_info
+      }
     ```
 
 Configurable options for values returned by CAS:

--- a/lib/omniauth/strategies/cas.rb
+++ b/lib/omniauth/strategies/cas.rb
@@ -189,8 +189,11 @@ module OmniAuth
     private
 
       def fetch_raw_info(ticket)
-        ticket_user_info = validate_service_ticket(ticket).user_info
-        custom_user_info = options.fetch_raw_info.call(self, options, ticket, ticket_user_info)
+        validator = validate_service_ticket(ticket)
+        ticket_user_info = validator.user_info
+        ticket_success_body = validator.success_body
+        custom_user_info = options.fetch_raw_info.call(self,
+          options, ticket, ticket_user_info, ticket_success_body)
         self.raw_info = ticket_user_info.merge(custom_user_info)
       end
 

--- a/lib/omniauth/strategies/cas/service_ticket_validator.rb
+++ b/lib/omniauth/strategies/cas/service_ticket_validator.rb
@@ -8,6 +8,8 @@ module OmniAuth
       class ServiceTicketValidator
         VALIDATION_REQUEST_HEADERS = { 'Accept' => '*/*' }
 
+        attr_reader :success_body
+
         # Build a validator from a +configuration+, a
         # +return_to+ URL, and a +ticket+.
         #

--- a/spec/fixtures/cas_success.xml
+++ b/spec/fixtures/cas_success.xml
@@ -10,5 +10,8 @@
     <cas:image>/images/user.jpg</cas:image>
     <cas:phone>555-555-5555</cas:phone>
     <cas:hire_date>2004-07-13</cas:hire_date>
+    <cas:roles>senator</cas:roles>
+    <cas:roles>lobbyist</cas:roles>
+    <cas:roles>financier</cas:roles>
   </cas:authenticationSuccess>
 </cas:serviceResponse>

--- a/spec/fixtures/cas_success_jasig.xml
+++ b/spec/fixtures/cas_success_jasig.xml
@@ -11,6 +11,9 @@
       <cas:image>/images/user.jpg</cas:image>
       <cas:phone>555-555-5555</cas:phone>
       <cas:hire_date>2004-07-13</cas:hire_date>
+      <cas:roles>senator</cas:roles>
+      <cas:roles>lobbyist</cas:roles>
+      <cas:roles>financier</cas:roles>
     </cas:attributes>
   </cas:authenticationSuccess>
 </cas:serviceResponse>


### PR DESCRIPTION
Exposes `ServiceTicketValidator.success_body` and passes it as a fifth argument to the user-supplied `fetch_raw_info` callback. This gives new clients access to the raw CAS XML response, allowing them to solve issues like #47 without breaking parsing for existing clients.

There were previously no tests for the `fetch_raw_info` callback. That is now implicitly tested by checks on new `cas:roles` fixture elements, which are populated by that callback.