### PR TITLE
Add support for multivalued attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Other configuration options:
   * `uid_field` - The user data attribute to use as your user's unique identifier. Defaults to `'user'` (which usually contains the user's login name).
   * `ca_path` - Optional when `ssl` is `true`. Sets path of a CA certification directory. See [Net::HTTP][net_http] for more details.
   * `disable_ssl_verification` - Optional when `ssl` is true. Disables verification.
+  * `merge_multivalued_attributes` - When set to `true` returns attributes with multiple values as arrays. Defaults to `false` and returns the last value as a string.
   * `on_single_sign_out` - Optional. Callback used when a [CAS 3.1 Single Sign Out][sso]
     request is received.
   * `fetch_raw_info` - Optional. Callback used to return additional "raw" user

--- a/lib/omniauth/strategies/cas.rb
+++ b/lib/omniauth/strategies/cas.rb
@@ -22,6 +22,7 @@ module OmniAuth
       option :port, nil
       option :path, nil
       option :ssl,  true
+      option :merge_multivalued_attributes, false
       option :service_validate_url, '/serviceValidate'
       option :login_url,            '/login'
       option :logout_url,           '/logout'

--- a/lib/omniauth/strategies/cas/service_ticket_validator.rb
+++ b/lib/omniauth/strategies/cas/service_ticket_validator.rb
@@ -42,6 +42,16 @@ module OmniAuth
 
       private
 
+        # Merges attributes with multiple values into an array if support is
+        # enabled (disabled by default)
+        def attribute_value(user_info, attribute, value)
+          if @options.merge_multivalued_attributes && user_info.key?(attribute)
+            Array(user_info[attribute]).push(value)
+          else
+            value
+          end
+        end
+
         # turns an `<cas:authenticationSuccess>` node into a Hash;
         # returns nil if given nil
         def parse_user_info(node)
@@ -52,11 +62,7 @@ module OmniAuth
               unless e.kind_of?(Nokogiri::XML::Text) || node_name == 'proxies'
                 # There are no child elements
                 if e.element_children.count == 0
-                  hash[node_name] = if hash[node_name] && @options.merge_multivalued_attributes
-                                      Array(hash[node_name]).push(e.content)
-                                    else
-                                      e.content
-                                    end
+                  hash[node_name] = attribute_value(hash, node_name, e.content)
                 elsif e.element_children.count
                   # JASIG style extra attributes
                   if node_name == 'attributes'

--- a/lib/omniauth/strategies/cas/service_ticket_validator.rb
+++ b/lib/omniauth/strategies/cas/service_ticket_validator.rb
@@ -52,7 +52,11 @@ module OmniAuth
               unless e.kind_of?(Nokogiri::XML::Text) || node_name == 'proxies'
                 # There are no child elements
                 if e.element_children.count == 0
-                  hash[node_name] = e.content
+                  hash[node_name] = if hash[node_name] && @options.merge_multivalued_attributes
+                                      Array(hash[node_name]).push(e.content)
+                                    else
+                                      e.content
+                                    end
                 elsif e.element_children.count
                   # JASIG style extra attributes
                   if node_name == 'attributes'

--- a/spec/omniauth/strategies/cas/service_ticket_validator_spec.rb
+++ b/spec/omniauth/strategies/cas/service_ticket_validator_spec.rb
@@ -9,6 +9,7 @@ describe OmniAuth::Strategies::CAS::ServiceTicketValidator do
   let(:provider_options) do
     double('provider_options',
       disable_ssl_verification?: false,
+      merge_multivalued_attributes: false,
       ca_path: '/etc/ssl/certsZOMG'
     )
   end
@@ -48,8 +49,26 @@ describe OmniAuth::Strategies::CAS::ServiceTicketValidator do
 
     subject { validator.user_info }
 
-    it 'parses user info from the response' do
-      expect(subject).to include 'user' => 'psegel'
+    context 'with default settings' do
+      it 'parses user info from the response' do
+        expect(subject).to include 'user' => 'psegel'
+        expect(subject).to include 'roles' => 'financier'
+      end
+    end
+
+    context 'when merging multivalued attributes' do
+      let(:provider_options) do
+        double('provider_options',
+          disable_ssl_verification?: false,
+          merge_multivalued_attributes: true,
+          ca_path: '/etc/ssl/certsZOMG'
+        )
+      end
+
+      it 'parses multivalued user info from the response' do
+        expect(subject).to include 'user' => 'psegel'
+        expect(subject).to include 'roles' => %w[senator lobbyist financier]
+      end
     end
   end
 end


### PR DESCRIPTION
Currently we use CAS to return multi-valued attributes like entitlements/roles, which aren't natively supported by this omniauth provider and instead get set to the last value returned. Looking to add optional support for returning these multi-valued attributes as arrays while maintaining backwards compatibility by default.