### PR TITLE
Preserve `url` parameter from POST body; don't append nil referer

### DIFF
--- a/lib/omniauth/strategies/cas.rb
+++ b/lib/omniauth/strategies/cas.rb
@@ -208,9 +208,13 @@ module OmniAuth
       end
 
       def return_url
-        # If the request already has a `url` parameter, then it will already be appended to the callback URL.
-        if request.params && request.params['url']
+        if request.GET['url']
+          # If the request URL query string already has a `url` parameter, then it will already be appended to the callback URL.
           {}
+        elsif (url = request.POST['url'])
+          # If /auth/calnet was called via POST (as recommended in https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284),
+          # we need to convert the posted `url` value to a query parameter if we want to preserve it.
+          { url: url }
         else
           { url: request.referer }
         end

--- a/lib/omniauth/strategies/cas.rb
+++ b/lib/omniauth/strategies/cas.rb
@@ -177,7 +177,8 @@ module OmniAuth
       def append_params(base, params)
         params = params.each { |k,v| v = Rack::Utils.escape(v) }
         Addressable::URI.parse(base).tap do |base_uri|
-          base_uri.query_values = (base_uri.query_values || {}).merge(params)
+          query_values = (base_uri.query_values || {}).merge(params)
+          base_uri.query_values = query_values.empty? ? nil : query_values
         end.to_s
       end
 
@@ -208,15 +209,15 @@ module OmniAuth
       end
 
       def return_url
-        if request.GET['url']
-          # If the request URL query string already has a `url` parameter, then it will already be appended to the callback URL.
-          {}
-        elsif (url = request.POST['url'])
-          # If /auth/calnet was called via POST (as recommended in https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284),
-          # we need to convert the posted `url` value to a query parameter if we want to preserve it.
-          { url: url }
-        else
-          { url: request.referer }
+        # If the request URL query string already has a `url` parameter, then it will already be appended to the callback URL.
+        # Otherwise, if /auth/calnet was called via POST (as in https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284),
+        # we need to convert the posted `url` value to a query parameter if we want to preserve it. If neither is present, but
+        # we have an HTTP 'Referer' header, we can use that.
+        {}.tap do |params|
+          next if request.GET['url']
+          next unless (url = request.POST['url'] || request.referer)
+
+          params[:url] = url
         end
       end
 


### PR DESCRIPTION
Previously, we were looking for `request.params['url']`, and assuming that if it was present, it would be in the original query string and OmniAuth would already have appended it to the callback URL. 

With this change, the behavior for a `url` parameter in the query string ([`Rack::Request#GET`](https://www.rubydoc.info/gems/rack/Rack/Request/Helpers#GET-instance_method) is unchanged. However, if there is no `url` parameter in the query string, but there is one in the form body, we transfer the value from the form body to the callback URL query string.

As a fallback, we use the HTTP `Referer` value, just as OmniAuth does for the `origin` parameter. However, we were previously appending it unconditionally, whether or not it was actually present (as it [often isn’t, for various reasons](https://en.wikipedia.org/wiki/HTTP_referer#Referrer_hiding)), resulting in an empty `url` query parameter in the callback URL. With this change, we now only append the referrer if non-nil.

Fixes #66.