### PR TITLE
Update for OmniAuth v2

### DIFF
--- a/lib/omniauth/strategies/cas.rb
+++ b/lib/omniauth/strategies/cas.rb
@@ -63,9 +63,14 @@ module OmniAuth
       end
 
       extra do
-        prune!(
-          raw_info.delete_if{ |k,v| AuthHashSchemaKeys.include?(k) }
-        )
+        hash = {}
+
+        unless skip_info?
+          hash = raw_info.dup
+          hash.delete_if { |k, _v| AuthHashSchemaKeys.include?(k) }
+        end
+
+        prune! hash
       end
 
       uid do

--- a/omniauth-cas.gemspec
+++ b/omniauth-cas.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Omniauth::Cas::VERSION
 
-  gem.add_dependency 'omniauth',                '~> 1.2'
+  gem.add_dependency 'omniauth',                '>= 1.2', '< 3'
   gem.add_dependency 'nokogiri',                '~> 1.5'
   gem.add_dependency 'addressable',             '~> 2.3'
 

--- a/spec/omniauth/strategies/cas_spec.rb
+++ b/spec/omniauth/strategies/cas_spec.rb
@@ -24,18 +24,32 @@ describe OmniAuth::Strategies::CAS, type: :strategy do
       run lambda { |env| [404, {'Content-Type' => 'text/plain'}, [env.key?('omniauth.auth').to_s]] }
     }.to_app
   end
+  let(:csrf_token) { SecureRandom.base64(32) }
+  let(:base_env) { { 'rack.session' => { csrf: csrf_token }, 'rack.input' => StringIO.new("authenticity_token=#{escaped_token}") } }
+  let(:post_env) { make_env('/auth/cas', base_env.merge(request_env)) }
+  let(:escaped_token) { URI.encode_www_form_component(csrf_token, Encoding::UTF_8) }
+
+  def make_env(path = '/auth/cas', props = {})
+    {
+      'REQUEST_METHOD' => 'POST',
+      'PATH_INFO' => path,
+      'rack.session' => {},
+      'rack.input' => StringIO.new('test=true')
+    }.merge(props)
+  end
 
   # TODO: Verify that these are even useful tests
   shared_examples_for 'a CAS redirect response' do
     let(:redirect_params) { 'service=' + Rack::Utils.escape("http://example.org/auth/cas/callback?url=#{Rack::Utils.escape(return_url)}") }
 
-    before { get url, nil, request_env }
+    before { post url, nil, post_env }
 
     subject { last_response }
 
     it { should be_redirect }
 
     it 'redirects to the CAS server' do
+      expect(subject.status).to eq(302)
       expect(subject.headers).to include 'Location' => "http://cas.example.org:8080/login?#{redirect_params}"
     end
   end
@@ -88,7 +102,7 @@ describe OmniAuth::Strategies::CAS, type: :strategy do
     it { should include('ssl' => true) }
   end
 
-  describe 'GET /auth/cas' do
+  describe 'POST /auth/cas' do
     let(:return_url) { 'http://myapp.com/admin/foo' }
 
     context 'with a referer' do


### PR DESCRIPTION
OmniAuth v2 converts all GET requests to POST requests by default
with CSRF protection.

Closes https://github.com/dlindahl/omniauth-cas/issues/62