### PR TITLE
Require Ruby >= 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
         channel: ['stable']
 
         include:

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'awesome_print'
 gem 'rack-test'
 gem 'rake'
 gem 'rspec'
+gem 'simplecov'
 gem 'webmock'
 
 # Specify your gem's dependencies in omniauth-cas.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
+
+gem 'awesome_print'
+gem 'rack-test'
+gem 'rake'
+gem 'rspec'
+gem 'webmock'
 
 # Specify your gem's dependencies in omniauth-cas.gemspec
 gemspec
-
-if RUBY_VERSION < "2.2.2"
-  # Rack 2 needs Ruby 2.2.2+
-  gem 'rack', '< 2'
-end

--- a/lib/omniauth/cas/version.rb
+++ b/lib/omniauth/cas/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Cas
-    VERSION = '2.0.0'
+    VERSION = '3.0.0'
   end
 end

--- a/omniauth-cas.gemspec
+++ b/omniauth-cas.gemspec
@@ -1,28 +1,32 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/omniauth/cas/version', __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path('lib/omniauth/cas/version', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Derek Lindahl"]
-  gem.email         = ["dlindahl@customink.com"]
-  gem.summary       = %q{CAS Strategy for OmniAuth}
+  gem.authors       = ['Derek Lindahl']
+  gem.email         = ['dlindahl@customink.com']
+  gem.summary       = 'CAS Strategy for OmniAuth'
   gem.description   = gem.summary
-  gem.homepage      = "https://github.com/dlindahl/omniauth-cas"
+  gem.homepage      = 'https://github.com/dlindahl/omniauth-cas'
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  gem.files         = `git ls-files`.split("\n")
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  gem.name          = "omniauth-cas"
-  gem.require_paths = ["lib"]
+  gem.files         = Dir.glob('{CHANGELOG.md,LICENSE,README.md,lib/**/*.rb}', File::FNM_DOTMATCH)
+  gem.name          = 'omniauth-cas'
+  gem.require_paths = ['lib']
   gem.version       = Omniauth::Cas::VERSION
 
-  gem.add_dependency 'omniauth',                '~> 1.2'
-  gem.add_dependency 'nokogiri',                '~> 1.5'
-  gem.add_dependency 'addressable',             '~> 2.3'
+  gem.metadata = {
+    'bug_tracker_uri' => 'https://github.com/dlindahl/omniauth-cas/issues',
+    'changelog_uri' => 'https://github.com/dlindahl/omniauth-cas/blob/master/CHANGELOG.md',
+    'documentation_uri' => 'https://dlindahl.github.io/omniauth-cas/',
+    'homepage_uri' => 'https://github.com/dlindahl/omniauth-cas',
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => 'https://github.com/dlindahl/omniauth-cas',
+    'wiki_uri' => 'https://github.com/dlindahl/omniauth-cas/wiki'
+  }
 
-  gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'webmock'
-  gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'rack-test'
+  gem.required_ruby_version = '>= 3.0'
 
-  gem.add_development_dependency 'awesome_print'
+  gem.add_dependency 'addressable', '~> 2.8'
+  gem.add_dependency 'nokogiri',    '~> 1.12'
+  gem.add_dependency 'omniauth',    '~> 1.9'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,11 @@
+if ENV['CI'] || ENV['COVERAGE']
+  require 'simplecov'
+
+  SimpleCov.start do
+    add_filter '/spec/'
+  end
+end
+
 require 'bundler/setup'
 require 'awesome_print'
 


### PR DESCRIPTION
Drop EOL Ruby versions and bump version to 3.0.0

Also refactor `gemspec`:
- Add metadata
- Opt-in for MFA requirement
- Do not assume that `git` is installed
- Move development dependencies to `Gemfile`

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/